### PR TITLE
vector: Enable certificate verification

### DIFF
--- a/charts/beta/vector/templates/cm.yaml
+++ b/charts/beta/vector/templates/cm.yaml
@@ -20,6 +20,7 @@ data:
         version: "2"
         tls:
           enabled: true
+          verify_certificate: true
           ca_file: "/etc/ssl/rubix-ca/ca.pem"
           crt_file: "/mnt/secrets/certs/tls.crt"
           key_file: "/mnt/secrets/certs/tls.key"


### PR DESCRIPTION
mTLS was not actually enabled since we never set the `verify_certificate` field on both the vector source and sink.

See https://github.com/vectordotdev/vector/issues/2017#issuecomment-1407089615 for more information
sources: https://vector.dev/docs/reference/configuration/sources/vector/#tls.verify_certificate
sinks: https://vector.dev/docs/reference/configuration/sinks/vector/#tls.verify_certificate