### PR TITLE
Fix: Don't abort on error when releasing

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -22,11 +22,11 @@ main() {
       if [[ -d "$chart" ]]; then
         chart_name=$(yq eval .name "${chart}/Chart.yaml")
         chart_version=$(yq eval .version "${chart}/Chart.yaml")
-        set +euo pipefail
+        set +e
         gh release view $chart_name-$chart_version >/dev/null 2>&1
         local exit_code=$?
-        set -euo pipefail
-        if [ $exit_code -eq 0 ];then
+        set -e
+        if [ $exit_code -eq 0 ]; then
           echo "Release '$chart_name-$chart_version' already exists...skipping."
         else
           echo "Creating release '$chart_name-$chart_version'"

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uo pipefail
+set -euo pipefail
 
 main() {
   : "${GH_TOKEN:?Environment variable GH_TOKEN must be set}"
@@ -22,8 +22,11 @@ main() {
       if [[ -d "$chart" ]]; then
         chart_name=$(yq eval .name "${chart}/Chart.yaml")
         chart_version=$(yq eval .version "${chart}/Chart.yaml")
+        set +euo pipefail
         gh release view $chart_name-$chart_version >/dev/null 2>&1
-        if [ $? -eq 0 ];then
+        local exit_code=$?
+        set -euo pipefail
+        if [ $exit_code -eq 0 ];then
           echo "Release '$chart_name-$chart_version' already exists...skipping."
         else
           echo "Creating release '$chart_name-$chart_version'"

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -uo pipefail
 
 main() {
   : "${GH_TOKEN:?Environment variable GH_TOKEN must be set}"


### PR DESCRIPTION
Surfaced from: https://github.com/palantir/fedstart-helm-charts/actions/runs/8823953443/job/24225494967

We check the exit code of `gh release view <release-name>` to see if a release exists, so we do not want to fail if this returns a non-zero exit code.