### PR TITLE
Rely on default labels instead of special apollo-app

### DIFF
--- a/charts/alpha/grafana/values.yaml
+++ b/charts/alpha/grafana/values.yaml
@@ -25,9 +25,6 @@ grafana:
       auto_assign_org: true
       auto_assign_org_role: "Admin"
 
-  extraLabels:
-    apollo-app: grafana
-
   livenessProbe:
     httpGet:
       path: /grafana/api/health
@@ -89,14 +86,11 @@ grafana:
         - podAffinityTerm:
             labelSelector:
               matchLabels:
-                apollo-app: grafana
+                app.kubernetes.io/name: grafana
             topologyKey: topology.kubernetes.io/zone
           weight: 100
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
-            matchExpressions:
-              - key: apollo-app
-                operator: In
-                values:
-                  - grafana
+            matchLabels:
+              app.kubernetes.io/name: grafana
           topologyKey: kubernetes.io/hostname

--- a/charts/beta/loki/values.yaml
+++ b/charts/beta/loki/values.yaml
@@ -6,8 +6,6 @@ loki:
   fullnameOverride: loki
   serviceAccount:
     name: loki
-    labels:
-      apollo-app: loki
 
   loki:
     analytics:
@@ -19,8 +17,6 @@ loki:
     podSecurityContext:
       seccompProfile:
         type: RuntimeDefault
-    podLabels:
-      apollo-app: loki
     readinessProbe:
       httpGet:
         path: /ready

--- a/charts/beta/prometheus/templates/alertmanager/cm.yaml
+++ b/charts/beta/prometheus/templates/alertmanager/cm.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    apollo-app: prometheus
+    {{- include "alertmanager.labels" . | nindent 4 }}
   name: "alertmanager-apollo-config"
 data:
   alertmanager-web-config.yml: |

--- a/charts/beta/prometheus/templates/prometheus/cm.yaml
+++ b/charts/beta/prometheus/templates/prometheus/cm.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    apollo-app: prometheus
+    {{- include "prometheus.server.labels" . | nindent 4 }}
   name: "prometheus-apollo-config"
 data:
   prometheus-web-config.yml: |

--- a/charts/beta/prometheus/values.yaml
+++ b/charts/beta/prometheus/values.yaml
@@ -51,9 +51,6 @@ prometheus:
       annotations:
         com.palantir.rubix.service/pod-cert: '{"staticReplicaCount":1}'
 
-    podLabels:
-      apollo-app: prometheus
-
     extraVolumeMounts:
       - name: cert-secret-volume
         mountPath: "/mnt/secrets/certs"
@@ -79,9 +76,6 @@ prometheus:
     service:
       annotations:
         com.palantir.rubix.service/pod-cert: '{"staticReplicaCount":1}'
-
-    podLabels:
-      apollo-app: prometheus
 
     securityContext:
       runAsGroup: null

--- a/charts/beta/vector/templates/cm.yaml
+++ b/charts/beta/vector/templates/cm.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: vector-aggregator-config
   labels:
-    apollo-app: vector
+    {{- include "vector.labels" . | nindent 4 }}
 data:
   aggregator.yaml: |
     data_dir: {{ .Values.vector.dataDir }}

--- a/charts/beta/vector/values.yaml
+++ b/charts/beta/vector/values.yaml
@@ -31,14 +31,6 @@ vector:
   # logLevel -- Log level for Vector.
   logLevel: "info"
 
-  # commonLabels - Labels to add to all created resources.
-  commonLabels:
-    apollo-app: vector-aggregator
-
-  # podLabels -- Labels to be set on vector pods.
-  podLabels:
-    apollo-app: vector-aggregator
-
   # replicas -- Number of pods to create.
   replicas: 2
 
@@ -162,15 +154,14 @@ vector:
         - podAffinityTerm:
             labelSelector:
               matchLabels:
-                apollo-app: vector-aggregator
+                app.kubernetes.io/component: Stateless-Aggregator
+                app.kubernetes.io/name: vector
             topologyKey: topology.kubernetes.io/zone
           weight: 100
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
-            matchExpressions:
-              - key: apollo-app
-                operator: In
-                values:
-                  - vector-aggregator
+            matchLabels:
+              app.kubernetes.io/component: Stateless-Aggregator
+              app.kubernetes.io/name: vector
           topologyKey: kubernetes.io/hostname
 


### PR DESCRIPTION
We dont need a special custom label given the default labels that are already added