### PR TITLE
Add annotated tags before creating a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Release charts
         run: |
           ./script/release.sh

--- a/script/release.sh
+++ b/script/release.sh
@@ -29,8 +29,12 @@ main() {
         if [ $exit_code -eq 0 ]; then
           echo "Release '$chart_name-$chart_version' already exists...skipping."
         else
+          echo "Creating annotated tag ($chart_name-$chart_version) for release..."
+          git tag -a $chart_name-$chart_version -m ""
+          echo "Pushing tag to origin..."
+          git push --tags
           echo "Creating release '$chart_name-$chart_version'"
-          gh release create $chart_name-$chart_version
+          gh release create $chart_name-$chart_version --notes-from-tag
         fi
       else
         echo "No changes found for '$chart'."


### PR DESCRIPTION
`gh release create <release-name>` creates lightweight tags instead of annotated ones which means there is a lack of metadata (specifically datetimes) associated with a tag. There is no native way to create an annotated tag via the `gh` cli, so instead we have to tag the commit, push the tag to remote, and then create the release using the annotated tag message as the release notes.