### PR TITLE
Stop creating k8s RBAC for Prometheus

### DIFF
--- a/charts/beta/prometheus/values.yaml
+++ b/charts/beta/prometheus/values.yaml
@@ -2,6 +2,9 @@
 
 ## Subchart value overrides
 prometheus:
+  rbac:
+    create: false
+
   serverFiles:
     prometheus.yml:
       scrape_configs: []


### PR DESCRIPTION
We don't use Prometheus's native k8s discovery for scraping metrics. Instead we remote_write metrics into Prometheus. Given that, we dont need to create RBAC from the prometheus helm chart.