### PR TITLE
Use chart-tester config instead of CLI args

### DIFF
--- a/.github/linters/ct.yaml
+++ b/.github/linters/ct.yaml
@@ -1,0 +1,14 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: develop
+debug: true
+validate-maintainers: false
+chart-dirs:
+  - charts/alpha
+  - charts/beta
+  - charts/ga
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
+  - grafana=https://grafana.github.io/helm-charts
+  - prometheus-community=https://prometheus-community.github.io/helm-charts
+  - vector=https://helm.vector.dev

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,12 +27,12 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --config .github/linters/ct.yaml)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --chart-dirs charts/* --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --config .github/linters/ct.yaml
 


### PR DESCRIPTION
Linting was not working properly for a couple reasons:
1. The `--chart-dirs` arg did not expand properly
2. The helm repos were not defined and thus not pulled down to run chart testing

Now the lint step will fail if there were changes to a chart and the `version` field in the Chart.yaml was not incremented.

Both vector and prometheus use a similar setup:
- vector: https://github.com/vectordotdev/helm-charts/blob/develop/.github/ct.yaml
- prometheus: https://github.com/prometheus-community/helm-charts/blob/main/.github/linters/ct.yaml