### PR TITLE
Set grafana deployment strategy to recreate

### DIFF
--- a/charts/alpha/grafana/Chart.yaml
+++ b/charts/alpha/grafana/Chart.yaml
@@ -12,7 +12,7 @@ description: A Grafana chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 7.3.7002
+version: 7.3.7003
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/alpha/grafana/values.yaml
+++ b/charts/alpha/grafana/values.yaml
@@ -43,6 +43,9 @@ grafana:
     timeoutSeconds: 30
     failureThreshold: 10
 
+  deploymentStrategy:
+    type: Recreate
+
   testFramework:
     enabled: false
   initChownData:


### PR DESCRIPTION
Switch grafana deployment strategy to Recreate instead of RollingUpdate.

When running in stateless mode with a persistent volume apollo plans hang when the new pod can't mount the persistent volume.  Grafana documentation for high availability configurations says using an external database is required, see https://grafana.com/docs/grafana/latest/setup-grafana/set-up-for-high-availability/