### PR TITLE
all: Fix linting issues for all charts

### DIFF
--- a/charts/alpha/grafana/Chart.lock
+++ b/charts/alpha/grafana/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: grafana
+  repository: https://grafana.github.io/helm-charts
+  version: 7.3.7
+digest: sha256:d1e082c5d966a130a20c5159d0e8d05495c27e83d7bc4f681dda6b71eaacc305
+generated: "2024-05-06T11:33:27.488244-04:00"

--- a/charts/alpha/grafana/Chart.yaml
+++ b/charts/alpha/grafana/Chart.yaml
@@ -12,7 +12,7 @@ description: A Grafana chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 7.3.7001
+version: 7.3.7002
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -21,5 +21,4 @@ version: 7.3.7001
 dependencies:
   - name: grafana
     version: "7.3.7"
-    charts: grafana
     repository: https://grafana.github.io/helm-charts

--- a/charts/alpha/redis/Chart.yaml
+++ b/charts/alpha/redis/Chart.yaml
@@ -12,7 +12,7 @@ description: A Redis chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 18.19.2007
+version: 18.19.2008
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -21,7 +21,6 @@ version: 18.19.2007
 dependencies:
   - name: redis
     version: "18.19.2"
-    charts: redis
     repository: oci://registry-1.docker.io/bitnamicharts
     # This is dependency for the bitnami redis chart and unfortunately helm only handles dependencies
     # at the first level. https://github.com/helm/helm/issues/2247

--- a/charts/alpha/redis/values.yaml
+++ b/charts/alpha/redis/values.yaml
@@ -6,13 +6,13 @@ redis:
   master:
     affinity:
       nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: com.palantir.rubix/instance-group
-                  operator: In
-                  values:
-                  - fedstart
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: com.palantir.rubix/instance-group
+                operator: In
+                values:
+                - fedstart
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -32,13 +32,13 @@ redis:
   replica:
     affinity:
       nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                - key: com.palantir.rubix/instance-group
-                  operator: In
-                  values:
-                  - fedstart
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+              - key: com.palantir.rubix/instance-group
+                operator: In
+                values:
+                - fedstart
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:

--- a/charts/beta/loki/Chart.yaml
+++ b/charts/beta/loki/Chart.yaml
@@ -12,7 +12,7 @@ description: A Loki chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 6.2.0001
+version: 6.2.0002
 
 # Be aware that using helm dependencies has undesirable side effects, where you cannot remove
 # sub-chart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/beta/loki/values.yaml
+++ b/charts/beta/loki/values.yaml
@@ -42,9 +42,9 @@ loki:
             period: 24h
     storage:
       type: s3
-      #s3:
-      #  region: us-east-1
-      #  endpoint: s3-fips.us-east-1.amazonaws.com
+      # s3:
+      #   region: us-east-1
+      #   endpoint: s3-fips.us-east-1.amazonaws.com
       bucketNames:
         chunks: chunks
         ruler: ruler

--- a/charts/beta/prometheus/Chart.yaml
+++ b/charts/beta/prometheus/Chart.yaml
@@ -12,7 +12,7 @@ description: A Prometheus chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 25.18.0004
+version: 25.18.0005
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -21,5 +21,4 @@ version: 25.18.0004
 dependencies:
 - name: prometheus
   version: "25.18.0"
-  charts: prometheus
   repository: https://prometheus-community.github.io/helm-charts

--- a/charts/beta/prometheus/values.yaml
+++ b/charts/beta/prometheus/values.yaml
@@ -20,9 +20,9 @@ prometheus:
       size: 100Gi
 
     resources:
-      #limits:
-      #  cpu: 500m
-      #  memory: 512Mi
+      # limits:
+      #   cpu: 500m
+      #   memory: 512Mi
       requests:
         cpu: 500m
         memory: 1Gi

--- a/charts/beta/vector/Chart.yaml
+++ b/charts/beta/vector/Chart.yaml
@@ -12,7 +12,7 @@ description: A Vector chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 0.31.1002
+version: 0.31.1003
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -21,5 +21,4 @@ version: 0.31.1002
 dependencies:
   - name: vector
     version: "0.31.1"
-    charts: vector
     repository: https://helm.vector.dev

--- a/charts/beta/vector/values.yaml
+++ b/charts/beta/vector/values.yaml
@@ -118,9 +118,9 @@ vector:
     requests:
       cpu: 1
       memory: 512Mi
-    #limits:
-    #  cpu: 200m
-    #  memory: 256Mi
+    # limits:
+    #   cpu: 200m
+    #   memory: 256Mi
 
   # podSecurityContext -- Ensures the pod is not run as root.
   podSecurityContext:
@@ -164,4 +164,3 @@ vector:
               app.kubernetes.io/component: Stateless-Aggregator
               app.kubernetes.io/name: vector
           topologyKey: kubernetes.io/hostname
-


### PR DESCRIPTION
Now that linting is actually running, this surfaced a few issues that would cause new PRs to fail. This change fixes all the current issues so that any new ones can be addressed on a per PR basis.

This was surfaced by a recent PR to update grafana which failed the lint step (https://github.com/palantir/fedstart-helm-charts/actions/runs/8971593367/job/24637657363?pr=36):
```
>>> yamale --schema /opt/hostedtoolcache/ct/3.10.0/amd64/etc/chart_schema.yaml charts/alpha/grafana/Chart.yaml
Validating /home/runner/work/fedstart-helm-charts/fedstart-helm-charts/charts/alpha/grafana/Chart.yaml...
Validation failed!
Error validating data '/home/runner/work/fedstart-helm-charts/fedstart-helm-charts/charts/alpha/grafana/Chart.yaml' with schema '/opt/hostedtoolcache/ct/3.10.0/amd64/etc/chart_schema.yaml'
	dependencies.0.charts: Unexpected element
------------------------------------------------------------------------------------------------------------------------
Error: failed linting charts: failed processing charts
 ✖︎ grafana => (version: "7.3.7002", path: "charts/alpha/grafana") > failed waiting for process: exit status 1
------------------------------------------------------------------------------------------------------------------------
failed linting charts: failed processing charts
```