### PR TITLE
grafana: Use a StatefulSet with replication of 2 for persistence instead of PVCs

### DIFF
--- a/charts/alpha/grafana/Chart.yaml
+++ b/charts/alpha/grafana/Chart.yaml
@@ -12,7 +12,7 @@ description: A Grafana chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 7.3.7002
+version: 7.3.7003
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/alpha/grafana/values.yaml
+++ b/charts/alpha/grafana/values.yaml
@@ -50,13 +50,15 @@ grafana:
   rbac:
     namespaced: true
 
+  replicas: 2
   persistence:
     enabled: true
+    type: statefulset
 
   service:
     annotations:
       com.palantir.rubix.service.spp/v3: '{"endpoints": [{"name": "service", "prefix": "{{ .Values.contextPath }}", "domain-aliases": ["DEFAULT"]}]}'
-      com.palantir.rubix.service/pod-cert: '{}'
+      com.palantir.rubix.service/pod-cert: '{"staticReplicaCount":2}'
   extraVolumeMounts:
     - name: tls-external-ca-bundle
       mountPath: "/etc/ssl/rubix-ca"
@@ -69,7 +71,7 @@ grafana:
             path: ca.pem
   extraSecretMounts:
     - name: cert-secret-volume
-      secretName: cert-grafana
+      secretName: cert-grafana-2
       mountPath: /mnt/secrets/certs
       readOnly: true
   affinity:


### PR DESCRIPTION
Moving to STS in place of https://github.com/palantir/fedstart-helm-charts/pull/36

By default, replicas is set to 1, and when persistence is enabled any upgrades are blocked due to multi-attach volume errors
- https://github.com/grafana/helm-charts/issues/146
- https://github.com/grafana/helm-charts/issues/1184

Moving to use a STS with replicas > 1 should allow upgrades to commence in an HA manner.