### PR TITLE
Use FIPS endpoint for ECR in product registration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following example packages the [vector](./charts/beta/vector) helm-chart, pu
 Pre-requisites:
 
 1. An ECR registry exists with a repository named `vector`
-   1. We will use `12345.dkr.ecr.us-east-1.amazonaws.com` where `accountID=12345` and `region=us-east-1`
+   1. We will use `12345.dkr.ecr-fips.us-east-1.amazonaws.com` where `accountID=12345` and `region=us-east-1`
 2. `helm`, `aws`, and `apollo-cli` are on the users `$PATH`
 3. `apollo-cli` is configured for the correct Apollo hub
 
@@ -76,12 +76,12 @@ $ helm package -d ./build ./charts/beta/vector
 Successfully packaged chart and saved it to: build/vector-0.31.1001.tgz
 
 # Get an AWS access-token and log into ECR using helm
-$ aws ecr get-login-password | helm registry login --username AWS --password-stdin 12345.dkr.ecr.us-east-1.amazonaws.com
+$ aws ecr get-login-password | helm registry login --username AWS --password-stdin 12345.dkr.ecr-fips.us-east-1.amazonaws.com
 Login Succeeded
 
 # Push the packaged helm-chart to ECR
-$ helm push ./build/vector-0.31.1001.tgz 12345.dkr.ecr.us-east-1.amazonaws.com
-Pushed: 12345.dkr.ecr.us-east-1.amazonaws.com/vector:0.31.1001
+$ helm push ./build/vector-0.31.1001.tgz 12345.dkr.ecr-fips.us-east-1.amazonaws.com
+Pushed: 12345.dkr.ecr-fips.us-east-1.amazonaws.com/vector:0.31.1001
 Digest: sha256:83fde30c20f51e3e1a071bddc21d0f0b4662002678dc5eb3b62c666bd0d568b9
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Once the packaged helm-chart is pushed to the container registry, we can now cre
 ```shell
 $ apollo-cli publish helm-chart \
     --chart-file ./build/vector-0.31.1001.tgz \
-    --helm-repository-url "oci://12345.dkr.ecr.us-east-1.amazonaws.com/vector" \
+    --helm-repository-url "oci://12345.dkr.ecr-fips.us-east-1.amazonaws.com/vector" \
     --maven-coordinate "com.palantir.vector:vector-aggregator:0.31.1001"
 Publishing product release com.palantir.vector:vector-aggregator:0.31.1001 into Apollo ... done
 ```


### PR DESCRIPTION
FedStart requires that all charts + images must use the FIPS endpoint from AWS. Updating the documentation to reference this endpoint in the instructions in publishing the helm chart to ensure that compliance is met.