### PR TITLE
loki: Update to 6.6.3 and add overrides for the gateway nginx image

### DIFF
--- a/charts/beta/loki/Chart.lock
+++ b/charts/beta/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana.github.io/helm-charts
-  version: 6.6.2
-digest: sha256:8a58f330ef833d0e9b1034d6a1e0fe2c76880aebd7013532d50c2bc51ae49bfa
-generated: "2024-06-06T18:44:59.63926-06:00"
+  version: 6.6.3
+digest: sha256:d4c0e179b5bb597b68cf0346fddfdc1a41cd7ebe81558b22eb724d2fc2eb2ca5
+generated: "2024-06-13T12:47:55.536478-04:00"

--- a/charts/beta/loki/Chart.yaml
+++ b/charts/beta/loki/Chart.yaml
@@ -12,7 +12,7 @@ description: A Loki chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 6.6.2002
+version: 6.6.3001
 
 # Be aware that using helm dependencies has undesirable side effects, where you cannot remove
 # sub-chart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 6.6.2002
 # https://github.com/helm/helm/issues/9027
 dependencies:
   - name: loki
-    version: "6.6.2"
+    version: "6.6.3"
     repository: https://grafana.github.io/helm-charts

--- a/charts/beta/loki/values.yaml
+++ b/charts/beta/loki/values.yaml
@@ -175,6 +175,10 @@ loki:
       publishNotReadyAddresses: true
 
   gateway:
+    image:
+      registry: docker.io
+      repository: nginxinc/nginx-unprivileged
+      tag: 1.26-alpine
     readinessProbe:
       httpGet:
         path: /


### PR DESCRIPTION
6.6.3 was released last week with 1 values.yaml fix: https://github.com/grafana/loki/releases/tag/helm-loki-6.6.3

The default image used in the loki-gateway has several critical CVEs that will prevent it from being installed in Apollo
ref: https://github.com/grafana/loki/issues/12960