### PR TITLE
Add Loki compactor overrides to set default S3 retention period

### DIFF
--- a/charts/beta/loki/Chart.yaml
+++ b/charts/beta/loki/Chart.yaml
@@ -12,7 +12,7 @@ description: A Loki chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 6.7.3001
+version: 6.7.3002
 
 # Be aware that using helm dependencies has undesirable side effects, where you cannot remove
 # sub-chart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/beta/loki/values.yaml
+++ b/charts/beta/loki/values.yaml
@@ -59,6 +59,12 @@ loki:
         active_index_directory: /var/loki/tsdb-shipper-active
         cache_location: /var/loki/tsdb-shipper-cache
         cache_ttl: 24h
+    limits_config:
+      # 18month retention period based on FedRAMP Guidance outlined in OMB M-21-31
+      retention_period: 550d
+    compactor:
+      retention_enabled: true
+      delete_request_store: s3
 
   # Disable chunks + results cache which use memcached (enabled by default)
   chunksCache:


### PR DESCRIPTION
PR adds default overrides to enable Loki Compactor and configure a 550day (18 month) retention period for logs stored in S3.