### PR TITLE
Upgrade alpha version of redis

### DIFF
--- a/charts/alpha/redis/Chart.yaml
+++ b/charts/alpha/redis/Chart.yaml
@@ -12,7 +12,7 @@ description: A Redis chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 18.19.2013
+version: 18.19.2014
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/alpha/redis/values.yaml
+++ b/charts/alpha/redis/values.yaml
@@ -18,16 +18,21 @@ redis:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  rubix-app: "{{ $.Release.Name }}-master"
+                  app.kubernetes.io/component: master
+                  app.kubernetes.io/instance: "{{ $.Release.Name }}"
               topologyKey: topology.kubernetes.io/zone
             weight: 100
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: rubix-app
+                - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - "{{ $.Release.Name }}-master"
+                    - "{{ $.Release.Name }}"
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - master
             topologyKey: kubernetes.io/hostname
   replica:
     affinity:
@@ -44,14 +49,19 @@ redis:
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
-                  rubix-app: "{{ $.Release.Name }}-replica"
+                  app.kubernetes.io/component: replica
+                  app.kubernetes.io/instance: "{{ $.Release.Name }}"
               topologyKey: topology.kubernetes.io/zone
             weight: 100
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: rubix-app
+                - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - "{{ $.Release.Name }}-replica"
+                    - "{{ $.Release.Name }}"
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                    - replica
             topologyKey: kubernetes.io/hostname

--- a/charts/alpha/redis/values.yaml
+++ b/charts/alpha/redis/values.yaml
@@ -25,14 +25,14 @@ redis:
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: app.kubernetes.io/instance
-                  operator: In
-                  values:
-                    - "{{ $.Release.Name }}"
                 - key: app.kubernetes.io/component
                   operator: In
                   values:
                     - master
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - "{{ $.Release.Name }}"
             topologyKey: kubernetes.io/hostname
   replica:
     affinity:
@@ -56,12 +56,12 @@ redis:
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-                - key: app.kubernetes.io/instance
-                  operator: In
-                  values:
-                    - "{{ $.Release.Name }}"
                 - key: app.kubernetes.io/component
                   operator: In
                   values:
                     - replica
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - "{{ $.Release.Name }}"
             topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Affinity and antiaffinity labels for redis have a match label that is no longer used. Updated to use appropriate match labels for both master and replica