### PR TITLE
Add Cloud KMS API to Prometheus Stackdriver Exporter defaults

### DIFF
--- a/charts/alpha/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/alpha/prometheus-stackdriver-exporter/Chart.yaml
@@ -12,7 +12,7 @@ description: A prometheus-stackdriver-exporter chart that can be used with Palan
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 4.9.0001
+version: 4.9.0002
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/alpha/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/alpha/prometheus-stackdriver-exporter/values.yaml
@@ -8,6 +8,7 @@ prometheus-stackdriver-exporter:
         - "redis.googleapis.com/"
         - "bigquery.googleapis.com/"
         - "pubsub.googleapis.com/"
+        - "cloudkms.googleapis.com/"
 
   extraEnv:
     - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
PR adds `cloudkms` API to prometheus stackdriver exporter defaults.