### PR TITLE
Add aiplatform.googleapis.com to defaults on prometheus-stackdriver-exporter

### DIFF
--- a/charts/alpha/prometheus-stackdriver-exporter/Chart.yaml
+++ b/charts/alpha/prometheus-stackdriver-exporter/Chart.yaml
@@ -12,7 +12,7 @@ description: A prometheus-stackdriver-exporter chart that can be used with Palan
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 4.9.0002
+version: 4.9.0003
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/alpha/prometheus-stackdriver-exporter/values.yaml
+++ b/charts/alpha/prometheus-stackdriver-exporter/values.yaml
@@ -9,6 +9,7 @@ prometheus-stackdriver-exporter:
         - "bigquery.googleapis.com/"
         - "pubsub.googleapis.com/"
         - "cloudkms.googleapis.com/"
+        - "aiplatform.googleapis.com/"
 
   extraEnv:
     - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
PR adds `aiplatform.googleapis.com` to defaults on prometheus-stackdriver-exporter