### PR TITLE
Disable prometheus scrapes by default to match previous behavior

### DIFF
--- a/charts/ga/prometheus/Chart.yaml
+++ b/charts/ga/prometheus/Chart.yaml
@@ -12,7 +12,7 @@ description: A Prometheus chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 28.9.0000
+version: 28.9.0001
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/ga/prometheus/values.yaml
+++ b/charts/ga/prometheus/values.yaml
@@ -5,9 +5,28 @@ prometheus:
   rbac:
     create: false
 
-  serverFiles:
-    prometheus.yml:
-      scrape_configs: []
+  # Disable scrapes by default
+  scrapeConfigs:
+    prometheus:
+      enabled: false
+    kubernetes-api-servers:
+      enabled: false
+    kubernetes-nodes:
+      enabled: false
+    kubernetes-nodes-cadvisor:
+      enabled: false
+    kubernetes-service-endpoints:
+      enabled: false
+    kubernetes-service-endpoints-slow:
+      enabled: false
+    prometheus-pushgateway:
+      enabled: false
+    kubernetes-services:
+      enabled: false
+    kubernetes-pods:
+      enabled: false
+    kubernetes-pods-slow:
+      enabled: false
 
   server:
     # Override if using mirrored container images


### PR DESCRIPTION
Previous upgrade PR brought in a breaking change for prometheus where the overrides to disable scrape_configs by default was moved.  See https://github.com/prometheus-community/helm-charts/pull/6429

This PR updates to the new values.yaml config options for disabling scrapes by default.