### PR TITLE
Make verify-CA default for database TLS

### DIFF
--- a/charts/ga/grafana/Chart.yaml
+++ b/charts/ga/grafana/Chart.yaml
@@ -12,7 +12,7 @@ description: A Grafana chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 10.5.15000
+version: 10.5.15001
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/ga/grafana/values.yaml
+++ b/charts/ga/grafana/values.yaml
@@ -38,7 +38,7 @@ grafana:
       type: postgres
       host: "__REPLACE_ME_DATABASE_HOST_DOMAIN"
       name: grafana
-      ssl_mode: require
+      ssl_mode: verify-ca
       # note, database username and password set in environment variables set by secret
       ca_cert_path: /etc/ssl/rubix-ca/ca.pem
       client_cert_path: /mnt/secrets/certs/tls.crt


### PR DESCRIPTION
## Before this PR
CA was unchecked, but the file explicitly set. For many deployments, this was irrelevant as the client did not require server verification. However, checking the CA is required for a handful of depoyments and generally safe+good practice for even the deployments that do not require server verification.

## After this PR
CA is now being checked.

## Possible downsides?
If CA file doesn't contain the right certs or users change the mounted cm without updating CA path, the connection will likely fail with "x509 certificate signed by unknown authority." Given the tls-external-ca-pem-bundle is explicitly mounted by default, the CA file should also work as intended by default.