### PR TITLE
Set Rubix CA path for Grafana and Loki

### DIFF
--- a/charts/ga/grafana/Chart.yaml
+++ b/charts/ga/grafana/Chart.yaml
@@ -12,7 +12,7 @@ description: A Grafana chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 11.3.2001
+version: 11.3.2002
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/ga/grafana/values.yaml
+++ b/charts/ga/grafana/values.yaml
@@ -18,6 +18,10 @@ grafana:
   admin:
     existingSecret: "__REPLACE_ME_ADMIN_CREDENTIALS_SECRET_NAME"
 
+  # Set CA path for datasources
+  env:
+    SSL_CERT_FILE: "/etc/ssl/rubix-ca/ca.pem"
+
   # Load GF_DATABASE_USER and GF_DATABASE_PASSWORD environment variables from secret
   envFromSecrets:
     - name: "__REPLACE_ME_DB_CREDENTIALS_SECRET_NAME"

--- a/charts/ga/loki/Chart.yaml
+++ b/charts/ga/loki/Chart.yaml
@@ -12,7 +12,7 @@ description: A Loki chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 6.55.0001
+version: 6.55.0002
 
 # Be aware that using helm dependencies has undesirable side effects, where you cannot remove
 # sub-chart config keys by setting them to null. If this type of configuration override is necessary,

--- a/charts/ga/loki/values.yaml
+++ b/charts/ga/loki/values.yaml
@@ -55,6 +55,8 @@ loki:
     storage:
       type: s3
       s3:
+        http_config:
+          ca_file: /etc/ssl/rubix-ca/ca.pem
         region: us-gov-west-1
       bucketNames:
         # Enter the name(s) of the buckets to use


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
On certain air-gapped environments that require custom CAs, we need to explicitly set the CA path for grafana and loki

## After this PR
Sets the CA path for grafana when making calls against all datasources and the CA path for Loki to write logs to S3

## Possible downsides?
The Rubix CA is set by default, but if the Rubix CA path is not set or mounted to a different path, these fields will need to be updated.
