### PR TITLE
Update vector, loki, prometheus, and grafana to latest

### DIFF
--- a/charts/ga/grafana/Chart.lock
+++ b/charts/ga/grafana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: grafana
   repository: https://grafana-community.github.io/helm-charts
-  version: 11.3.2
-digest: sha256:055827a7b758365697278ae9ebb37c1950aea133544aec1f5862bf8e07f3abc8
-generated: "2026-03-12T15:46:55.352235-06:00"
+  version: 12.3.0
+digest: sha256:7122c700b44d3e307286e93483be0ef9b79a0b0bded1cc794a331e6557f9b9db
+generated: "2026-05-07T01:40:21.527004-06:00"

--- a/charts/ga/grafana/Chart.yaml
+++ b/charts/ga/grafana/Chart.yaml
@@ -12,7 +12,7 @@ description: A Grafana chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 11.3.2002
+version: 12.3.0001
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 11.3.2002
 # https://github.com/helm/helm/issues/9027
 dependencies:
   - name: grafana
-    version: "11.3.2"
+    version: "12.3.0"
     repository: https://grafana-community.github.io/helm-charts

--- a/charts/ga/loki/Chart.lock
+++ b/charts/ga/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
-  repository: https://grafana.github.io/helm-charts
-  version: 6.55.0
-digest: sha256:2e09dd20884300bed8826aa0742382dceefa4423c14b916a2f59cb694897d7e5
-generated: "2026-03-12T15:37:02.324804-06:00"
+  repository: https://grafana-community.github.io/helm-charts
+  version: 13.6.1
+digest: sha256:85e4110940c1a5dc98b664481faba31c8e57c6d97b2e00a9e01b3d8d03519273
+generated: "2026-05-07T01:38:33.799322-06:00"

--- a/charts/ga/loki/Chart.yaml
+++ b/charts/ga/loki/Chart.yaml
@@ -12,7 +12,7 @@ description: A Loki chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 6.55.0002
+version: 13.6.1001
 
 # Be aware that using helm dependencies has undesirable side effects, where you cannot remove
 # sub-chart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 6.55.0002
 # https://github.com/helm/helm/issues/9027
 dependencies:
   - name: loki
-    version: "6.55.0"
-    repository: https://grafana.github.io/helm-charts
+    version: "13.6.1"
+    repository: https://grafana-community.github.io/helm-charts

--- a/charts/ga/loki/README.md
+++ b/charts/ga/loki/README.md
@@ -4,7 +4,7 @@ A Palantir Fedstart compliant helm-chart for [loki](https://github.com/grafana/l
 
 ## Configuration
 
-Refer to the Loki [documentation](https://grafana.com/docs/loki/next/setup/install/helm/reference/) or the sub-chart [values.yaml](https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml) for all available upstream configuration options
+Refer to the Loki [documentation](https://grafana.com/docs/loki/next/setup/install/helm/reference/) or the sub-chart [values.yaml](https://github.com/grafana-community/helm-charts/blob/main/charts/loki/values.yaml) for all available upstream configuration options
 
 ### Pre-requisites
 
@@ -22,7 +22,7 @@ The following config overrides must be applied to Loki when installing for the f
   overrides:
     fedstart:
       s3:
-        aws_role_arn: "arn:aws-us-gov:iam::<account-number>:role/fedstart-default-role"
+        aws_role_arn: "arn:aws-us-gov:iam::<account-number>:role/observability"
     loki:
       loki:
         storage:

--- a/charts/ga/loki/values.yaml
+++ b/charts/ga/loki/values.yaml
@@ -14,6 +14,8 @@ loki:
   #   # -- Overrides the Docker registry globally for all images
   #   registry: null
 
+  deploymentMode: SimpleScalable
+
   nameOverride: loki
   fullnameOverride: loki
   serviceAccount:
@@ -35,6 +37,15 @@ loki:
         port: http-metrics
         scheme: HTTPS
       initialDelaySeconds: 45
+      timeoutSeconds: 1
+    livenessProbe:
+      httpGet:
+        path: /loki/api/v1/status/buildinfo
+        port: http-metrics
+        scheme: HTTPS
+      periodSeconds: 30
+      successThreshold: 1
+      failureThreshold: 10
       timeoutSeconds: 1
     server:
       log_format: json
@@ -120,7 +131,6 @@ loki:
                   - fedstart
 
   read:
-    legacyReadTarget: false
     service:
       annotations:
         com.palantir.rubix.service/pod-cert: '{}'
@@ -194,13 +204,14 @@ loki:
     readinessProbe:
       httpGet:
         path: /
-        port: http-metrics
+        port: http
         scheme: HTTPS
       initialDelaySeconds: 45
       timeoutSeconds: 1
     nginxConfig:
       schema: https
       ssl: true
+      enableIPv6: false
       serverSnippet: |
         ssl_certificate     /mnt/secrets/certs/tls.crt;
         ssl_certificate_key /mnt/secrets/certs/tls.key;
@@ -212,6 +223,10 @@ loki:
       annotations:
         com.palantir.rubix.service/pod-cert: "{}"
       port: 443
+    metrics:
+      service:
+        annotations:
+          com.palantir.rubix.service/pod-cert: "{}"
     extraEnvFrom:
       - configMapRef:
           name: loki-aws-s3-config

--- a/charts/ga/prometheus/Chart.lock
+++ b/charts/ga/prometheus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 28.13.0
-digest: sha256:8f0b441d0a7cc395a4092a9ee1c76882e2cf4e26c2c831ed4c64657fbf49355b
-generated: "2026-03-12T15:35:33.155853-06:00"
+  version: 29.6.0
+digest: sha256:63ae5bd0c905849660f1b5faef804317bd0c747958626e0a0890a068acc71919
+generated: "2026-05-07T01:36:17.951696-06:00"

--- a/charts/ga/prometheus/Chart.yaml
+++ b/charts/ga/prometheus/Chart.yaml
@@ -12,7 +12,7 @@ description: A Prometheus chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 28.13.0001
+version: 29.6.0001
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 28.13.0001
 # https://github.com/helm/helm/issues/9027
 dependencies:
 - name: prometheus
-  version: "28.13.0"
+  version: "29.6.0"
   repository: https://prometheus-community.github.io/helm-charts

--- a/charts/ga/prometheus/values.yaml
+++ b/charts/ga/prometheus/values.yaml
@@ -74,6 +74,7 @@ prometheus:
         type: RuntimeDefault
 
     service:
+      servicePort: 443
       annotations:
         com.palantir.rubix.service/pod-cert: '{"staticReplicaCount":1}'
 

--- a/charts/ga/vector/Chart.lock
+++ b/charts/ga/vector/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: vector
   repository: https://helm.vector.dev
-  version: 0.51.0
-digest: sha256:13c9414dea1d0de4dba1a3de27560bc6fe161037ce786a9f67408d6edc2823d1
-generated: "2026-03-12T15:35:14.787059-06:00"
+  version: 0.52.0
+digest: sha256:6e62cb7398a723721cb0981cf895e115189b3b6cc892b8a35b43417954339e54
+generated: "2026-05-07T01:35:13.087701-06:00"

--- a/charts/ga/vector/Chart.yaml
+++ b/charts/ga/vector/Chart.yaml
@@ -12,7 +12,7 @@ description: A Vector chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 0.51.0001
+version: 0.52.0001
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 0.51.0001
 # https://github.com/helm/helm/issues/9027
 dependencies:
   - name: vector
-    version: "0.51.0"
+    version: "0.52.0"
     repository: https://helm.vector.dev

--- a/charts/ga/vector/templates/cm.yaml
+++ b/charts/ga/vector/templates/cm.yaml
@@ -11,7 +11,6 @@ data:
     api:
       enabled: true
       address: 0.0.0.0:8686
-      playground: false
     # https://vector.dev/docs/reference/configuration/sources/vector/
     sources:
       daemonset:


### PR DESCRIPTION
Update versions

- vector => 0.52.0
- prometheus => 29.6.0 (note, updates port to 443 to match https)
- loki => 13.6.1 (note, switches to grafana community helm chart)
- grafana => 12.3.0
