### PR TITLE
Update loki, prometheus, grafana versions

### DIFF
--- a/charts/ga/grafana/Chart.lock
+++ b/charts/ga/grafana/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: grafana
   repository: https://grafana-community.github.io/helm-charts
-  version: 12.3.0
-digest: sha256:7122c700b44d3e307286e93483be0ef9b79a0b0bded1cc794a331e6557f9b9db
-generated: "2026-05-07T01:40:21.527004-06:00"
+  version: 12.4.1
+digest: sha256:4a5d1855302d0a5dbc8ef012e992da32208241429058bb4de12e7b3989038e11
+generated: "2026-06-02T09:20:01.645884-06:00"

--- a/charts/ga/grafana/Chart.yaml
+++ b/charts/ga/grafana/Chart.yaml
@@ -12,7 +12,7 @@ description: A Grafana chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 12.3.0001
+version: 12.4.1001
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 12.3.0001
 # https://github.com/helm/helm/issues/9027
 dependencies:
   - name: grafana
-    version: "12.3.0"
+    version: "12.4.1"
     repository: https://grafana-community.github.io/helm-charts

--- a/charts/ga/loki/Chart.lock
+++ b/charts/ga/loki/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: loki
   repository: https://grafana-community.github.io/helm-charts
-  version: 13.6.1
-digest: sha256:85e4110940c1a5dc98b664481faba31c8e57c6d97b2e00a9e01b3d8d03519273
-generated: "2026-05-07T01:38:33.799322-06:00"
+  version: 17.1.6
+digest: sha256:69d9a31d2ed7dbfbafd7e9ffafa9148d18d1baaa112806bc53bbd7d3d44bbcf0
+generated: "2026-06-02T08:18:58.508707-06:00"

--- a/charts/ga/loki/Chart.yaml
+++ b/charts/ga/loki/Chart.yaml
@@ -12,7 +12,7 @@ description: A Loki chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 13.6.1001
+version: 17.1.6001
 
 # Be aware that using helm dependencies has undesirable side effects, where you cannot remove
 # sub-chart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 13.6.1001
 # https://github.com/helm/helm/issues/9027
 dependencies:
   - name: loki
-    version: "13.6.1"
+    version: "17.1.6"
     repository: https://grafana-community.github.io/helm-charts

--- a/charts/ga/prometheus/Chart.lock
+++ b/charts/ga/prometheus/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 29.6.0
-digest: sha256:63ae5bd0c905849660f1b5faef804317bd0c747958626e0a0890a068acc71919
-generated: "2026-05-07T01:36:17.951696-06:00"
+  version: 29.9.0
+digest: sha256:2356f010afe000f22a73ea3f523182e2e5a4e1dd1cf28de58a1afd0bfc240c19
+generated: "2026-06-02T08:52:51.969543-06:00"

--- a/charts/ga/prometheus/Chart.yaml
+++ b/charts/ga/prometheus/Chart.yaml
@@ -12,7 +12,7 @@ description: A Prometheus chart that can be used with Palantir FedStart
 # pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-version: 29.6.0001
+version: 29.9.0001
 
 # Be aware that using helm dependencies has undesirable side affects, where you cannot remove
 # subchart config keys by setting them to null. If this type of configuration override is necessary,
@@ -20,5 +20,5 @@ version: 29.6.0001
 # https://github.com/helm/helm/issues/9027
 dependencies:
 - name: prometheus
-  version: "29.6.0"
+  version: "29.9.0"
   repository: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
Update versions:
- grafana -> 12.4.1
- loki -> 17.1.6
- prometheus -> 29.9.0